### PR TITLE
Append express to links, adjust reference provider

### DIFF
--- a/lib/Reference/PexipReferenceProvider.php
+++ b/lib/Reference/PexipReferenceProvider.php
@@ -132,8 +132,10 @@ class PexipReferenceProvider extends ADiscoverableReferenceProvider  {
 		$pexipUrl = $this->config->getAppValue(Application::APP_ID, 'pexip_url');
 			$this->urlGenerator->getAbsoluteURL('/apps/' . Application::APP_ID);
 
-		// link example: https://pexip.example/webapp3/m/3jf5wq3hibbqvickir7ysqehfi
-		preg_match('/^' . preg_quote($pexipUrl, '/') . '\/webapp3\/m\/([0-9a-z]+)$/i', $url, $matches);
+		// link examples:
+		// https://pexip.example/webapp3/m/3jf5wq3hibbqvickir7ysqehfi
+		// https://pexip.example/webapp3/m/3jf5wq3hibbqvickir7ysqehfi/express
+		preg_match('/^' . preg_quote($pexipUrl, '/') . '\/webapp3\/m\/([0-9a-z]+)(?:\/express)?$/i', $url, $matches);
 		if (count($matches) > 1) {
 			return $matches[1];
 		}

--- a/lib/Service/PexipService.php
+++ b/lib/Service/PexipService.php
@@ -92,12 +92,12 @@ class PexipService {
 	}
 
 	/**
-	 * @param string $pexipurl
+	 * @param string $pexipUrl
 	 * @param string $pexipId
 	 * @return string
 	 */
 	private function getCallLink(string $pexipUrl, string $pexipId): string {
-		return trim($pexipUrl, " \n\r\t\v\x00/") . '/webapp3/m/' . $pexipId;
+		return trim($pexipUrl, " \n\r\t\v\x00/") . '/webapp3/m/' . $pexipId . '/express';
 	}
 
 	/**

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -63,7 +63,7 @@ export default {
 			return t('integration_pexip', 'On the Pexip side, the "policy server URI" must be set to {policyUri}', { policyUri: this.policyUri })
 		},
 		meetingLinkHint() {
-			const linkExample = this.state.pexip_url + '/webapp3/m/MEETING_ID'
+			const linkExample = this.state.pexip_url + '/webapp3/m/MEETING_ID/express'
 			return t('integration_pexip', 'Nextcloud will generate meeting links like {linkExample}', { linkExample })
 		},
 	},


### PR DESCRIPTION
The supported links are now:
* https://pexip.example/webapp3/m/3jf5wq3hibbqvickir7ysqehfi
* https://pexip.example/webapp3/m/3jf5wq3hibbqvickir7ysqehfi/express

NC now generates links with /express.